### PR TITLE
Add prospector-json as a Reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 docs/build
 .vscode
 __pycache__
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ poetry.lock
 dist
 docs/build
 .vscode
+__pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ csv = "tidypy.reports.structured:CsvReport"
 pylint = "tidypy.reports.pylint:PyLintReport"
 pylint-parseable = "tidypy.reports.pylint:PyLintParseableReport"
 null = "tidypy.reports.null:NullReport"
+prospector-json = "tidypy.reports.prospector_json:ProspectorJsonReport"
 
 [tool.poetry.plugins."tidypy.extenders"]
 github = "tidypy.extenders.github:GithubExtender"

--- a/src/tidypy/reports/prospector_json.py
+++ b/src/tidypy/reports/prospector_json.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+import basicserial
+
+from ..config import get_tools
+from .base import Report
+
+
+class ProspectorJsonReport(Report):
+    """
+    Formats the report in Prospector JSON format.
+    """
+
+    def execute(self, collector):
+        issues = collector.get_issues(sortby=("filename", "line", "character"))
+        result_json = {
+            "summary": {
+                "started": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "libraries": [],
+                "strictness": "from profile",
+                "profiles": "tidypy",
+                "tools": list(get_tools().keys()),
+                "message_count": collector.issue_count(),
+                "completed": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "time_taken": "0",
+                "formatter": "json",
+            },
+            "messages": [
+                {
+                    "source": issue.tool,
+                    "code": issue.code,
+                    "location": {
+                        "path": self.relative_filename(issue.filename),
+                        "module": None,
+                        "function": None,
+                        "line": issue.line,
+                        "character": issue.character or 0,
+                    },
+                    "message": issue.message,
+                }
+                for issue in issues
+            ],
+        }
+        self.output(basicserial.to_json(result_json, pretty=True))

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -57,6 +57,7 @@ def test_get_reports():
         'custom',
         'json',
         'null',
+        'prospector-json',
         'pycodestyle',
         'pylint',
         'pylint-parseable',


### PR DESCRIPTION
Did this while trying to get tidpy to work in vscode, nothing too complex.
tries to as closely as possible emulate the prospector json format, though some things had to be faked such as start/end timestamps and duration, as i couldn't figure out whether those were collected or in any way accessible for a Reporter.

test suite + linter should have run and passed.